### PR TITLE
Switch message names to pascal case in Runtime Manager

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -51,7 +51,7 @@ subs :
         param: ndt
         gui  :
           dialog_height : 550
-          stat_topic : [ /ndt_stat.ndt_stat.exe_time ]
+          stat_topic : [ /NDTStat.ndt_stat.exe_time ]
           x  :
             user_category : ''
           yaw:

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -2312,7 +2312,7 @@ params :
 
   - name : feat_proj
     topic: /config/adjust_xy
-    msg  : adjust_xy
+    msg  : AdjustXY
     vars :
     - name : x
       desc : x desc sample
@@ -2495,7 +2495,7 @@ params :
 
   - name  : lane_stop
     topic : /light_color_managed
-    msg   : traffic_light
+    msg   : TrafficLight
     no_save_vars : [ lane_stop ]
     vars  :
     - name  : traffic_light

--- a/ros/src/util/packages/runtime_manager/scripts/interface.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/interface.yaml
@@ -31,7 +31,7 @@ checkboxs :
 params :
   - name  : accel
     topic : /accel_cmd
-    msg   : accel_cmd
+    msg   : AccelCmd
     vars  :
     - name  : accel
       label : Accel
@@ -40,7 +40,7 @@ params :
       v     : 0
   - name  : brake
     topic : /brake_cmd
-    msg   : brake_cmd
+    msg   : BrakeCmd
     vars  :
     - name  : brake
       label : Brake
@@ -49,7 +49,7 @@ params :
       v     : 0
   - name  : steer
     topic : /steer_cmd
-    msg   : steer_cmd
+    msg   : SteerCmd
     vars  :
     - name  : steer
       label : Steer

--- a/ros/src/util/packages/runtime_manager/scripts/main.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/main.yaml
@@ -157,7 +157,7 @@ params :
       v     : 0
   - name  : brake
     topic : /brake_cmd
-    msg   : brake_cmd
+    msg   : BrakeCmd
     vars  :
     - name  : brake
       label : Brake
@@ -166,7 +166,7 @@ params :
       v     : 0
   - name  : steer
     topic : /steer_cmd
-    msg   : steer_cmd
+    msg   : SteerCmd
     vars  :
     - name  : steer
       label : Steer

--- a/ros/src/util/packages/runtime_manager/scripts/main.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/main.yaml
@@ -148,7 +148,7 @@ control_check :
 params :
   - name  : accel
     topic : /accel_cmd
-    msg   : accel_cmd
+    msg   : AccelCmd
     vars  :
     - name  : accel
       label : Accel

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -1,6 +1,6 @@
 exec_time :
   localization :
-    /ndt_stat.ndt_stat.exe_time :
+    /NDTStat.ndt_stat.exe_time :
   detection :
     /topic1 :
     /topic2 :

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -90,6 +90,9 @@ from tablet_socket_msgs.msg import Waypoint
 from tablet_socket_msgs.msg import route_cmd
 from geometry_msgs.msg import TwistStamped
 from geometry_msgs.msg import Vector3
+from autoware_msgs.msg import AccelCmd
+from autoware_msgs.msg import SteerCmd
+from autoware_msgs.msg import BrakeCmd
 from autoware_msgs.msg import IndicatorCmd
 from autoware_msgs.msg import LampCmd
 from autoware_msgs.msg import TrafficLight


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Switch message names to pascal case in Runtime Manager.
Fixed a issue where Runtime Manager does not appear at https://github.com/CPFL/Autoware/pull/1408#issuecomment-429516278.


## Related PRs

branch | PR
------ | ------
fix/pascal_case_msgs | https://github.com/CPFL/Autoware/pull/1408


## Todos
- [x] Tests

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
cd Autoware/ros
./catkin_make_release
./run
```
Autoware should work as it was before.